### PR TITLE
Pass token by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ jobs:
       id: action
       uses: kamatama41/hide-pr-comments-action@v0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
         author: my-system-bot                 # OPTIONAL
         message_regex: "Test result: (OK|NG)" # OPTIONAL
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ inputs:
   github_token:
     description: 'Access token of GitHub'
     required: true
+    default: ${{ github.token }}
   author:
     description: 'Username of author'
     required: false


### PR DESCRIPTION
As it is mandatory and mostly always be `secrets.GITHUB_TOKEN`. 